### PR TITLE
Fixing for test-method signatures that include generic types, and can…

### DIFF
--- a/src/main/java/sushi/compile/path_condition_distance/CandidateBackbone.java
+++ b/src/main/java/sushi/compile/path_condition_distance/CandidateBackbone.java
@@ -13,7 +13,7 @@ public class CandidateBackbone {
 	private final ClassLoader classLoader;
 	
 	// We keep the direct and reverse mapping between visited objects and their origins 
-	private final Map<ObjectMapWrapper, String> visitedObjects = new HashMap<ObjectMapWrapper, String>(); 
+	private final Map<ObjectMapWrapper, String> freshObjects = new HashMap<ObjectMapWrapper, String>(); 
 	private final Map<String, Object> visitedOrigins = new HashMap<String, Object>(); 
 	private final Collection<String> invalidFieldPaths = new HashSet<String>(); 
 	
@@ -33,6 +33,7 @@ public class CandidateBackbone {
 			_I = new CandidateBackbone(classLoader);
 		} else {
 			_I.invalidFieldPaths.clear(); /* the information on the invalid field paths is specific for each path condition and shall not be reused across path conditions */
+			_I.freshObjects.clear();
 		}
 		return _I;
 	}
@@ -42,29 +43,24 @@ public class CandidateBackbone {
 		_I = null; // resetting the backbone
 	}
 
-	private void storeInBackbone(Object obj, String origin) {
+	private void storeInBackboneIfFresh(Object obj, String origin) {
 		// If another origin already exist for a non-null object, this is an alias path
 		// and then it shall not be stored
-		// Moreover null values are stored with corresponding origins, but not vice-versa since 
-		// they do not participate in deciding aliases 
-		if ((obj == null && !this.visitedOrigins.containsKey(origin)) || (obj != null && !this.visitedObjects.containsKey(new ObjectMapWrapper(obj)))) {
-			this.visitedOrigins.put(origin, obj);
-			if (obj != null) {
-				this.visitedObjects.put(new ObjectMapWrapper(obj), origin);
-			}
+		if (obj != null && !this.freshObjects.containsKey(new ObjectMapWrapper(obj))) {
+			this.freshObjects.put(new ObjectMapWrapper(obj), origin);
 		}
 	}
 
-	public boolean isVisitedObject(String origin) {
+	public boolean isVisitedOrigin(String origin) {
 		return this.visitedOrigins.containsKey(origin);
 	}
 
-	public Object getVisitedObject(String origin) {
+	public Object getObjectByOrigin(String origin) {
 		return this.visitedOrigins.get(origin);
 	}
 
 	public String getOrigin(Object obj) {
-		return this.visitedObjects.get(new ObjectMapWrapper(obj));
+		return this.freshObjects.get(new ObjectMapWrapper(obj));
 	}
 
 	public void addInvalidFieldPath(String refPath) {
@@ -108,14 +104,16 @@ public class CandidateBackbone {
 			cache = new SushiLibCache(); //no-cache behavior: use a throw-away local cache 
 		}
 		
-		//check in the cache of the visited object
-		if (isVisitedObject(origin)) {
-			return getVisitedObject(origin);
+		Object obj;
+		// for origins that are not function calls, check in the cache of the visited object
+		if (origin.charAt(0) != '<' && isVisitedOrigin(origin)) {
+			obj = getObjectByOrigin(origin);
+		} else {
+			ParsedOrigin parsedOrigin = cache.getParsedOrigin(origin);
+			obj = parsedOrigin.get(candidateObjects, this, constants, cache);
+			this.visitedOrigins.put(origin, obj);			
 		}
-		
-		ParsedOrigin parsedOrigin = cache.getParsedOrigin(origin);
-		Object obj = parsedOrigin.get(candidateObjects, this, constants, cache);
-		storeInBackbone(obj, origin);
+		storeInBackboneIfFresh(obj, origin);
 		return obj;
 	}
 	

--- a/src/main/java/sushi/compile/path_condition_distance/SimilarityWithRefNotAlias.java
+++ b/src/main/java/sushi/compile/path_condition_distance/SimilarityWithRefNotAlias.java
@@ -20,7 +20,9 @@ public class SimilarityWithRefNotAlias extends SimilarityWithRef {
 		
 		double similarity;
 		
-		Object alias = backbone.getVisitedObject(theAliasOrigin);
+		/* Note that the aliased object must have been retrieved in the past,
+		 * thus we do not need to call backbone.retrieveOrVisitField in this case */
+		Object alias = backbone.getObjectByOrigin(theAliasOrigin);
 
 		if (referredObject != null && referredObject == alias) {
 			logger.debug("Unconfirmed non-matching aliases. There is match between field " + theReferenceOrigin + " and field " + theAliasOrigin);

--- a/src/main/java/sushi/compile/path_condition_distance/SimilarityWithRefToAlias.java
+++ b/src/main/java/sushi/compile/path_condition_distance/SimilarityWithRefToAlias.java
@@ -22,7 +22,7 @@ public class SimilarityWithRefToAlias extends SimilarityWithRef {
 		
 		double similarity = 0.0d;
 		
-		Object alias = backbone.getVisitedObject(theAliasOrigin);
+		Object alias = backbone.getObjectByOrigin(theAliasOrigin);
 
 		if (referredObject != null && referredObject == alias) {
 			logger.debug("Matching aliases between field " + theReferenceOrigin + " and field " + theAliasOrigin);

--- a/src/main/java/sushi/compile/path_condition_distance/SimilarityWithRefToAlias.java
+++ b/src/main/java/sushi/compile/path_condition_distance/SimilarityWithRefToAlias.java
@@ -22,7 +22,9 @@ public class SimilarityWithRefToAlias extends SimilarityWithRef {
 		
 		double similarity = 0.0d;
 		
-		Object alias = backbone.getObjectByOrigin(theAliasOrigin);
+		/* Note that the aliased object must have been retrieved in the past,
+		 * thus we do not need to call backbone.retrieveOrVisitField in this case */
+		Object alias = backbone.getObjectByOrigin(theAliasOrigin); 
 
 		if (referredObject != null && referredObject == alias) {
 			logger.debug("Matching aliases between field " + theReferenceOrigin + " and field " + theAliasOrigin);

--- a/src/main/java/sushi/formatters/StateFormatterSushiPathCondition.java
+++ b/src/main/java/sushi/formatters/StateFormatterSushiPathCondition.java
@@ -238,7 +238,7 @@ public final class StateFormatterSushiPathCondition implements FormatterSushi {
                 final char type = ((Primitive) symbol).getType();
                 return javaPrimitiveType(type);
             } else if (symbol instanceof ReferenceSymbolic) {
-                final String className = javaClass(((ReferenceSymbolic) symbol).getStaticType(), true);
+                final String className = "java.lang.Object"; //We declare all reference-typed parameters with type Object - EvoSuite will pass the correct types dynamically
                 return className;
             } else {
                 //this should never happen


### PR DESCRIPTION
…not be compiled as a result. Now We declare all reference-typed parameters with type Object - EvoSuite will pass the correct types dynamically.